### PR TITLE
Convenience not_exists_ok additions to truncate and drop

### DIFF
--- a/cottontaildb_client/cottontaildb_client.py
+++ b/cottontaildb_client/cottontaildb_client.py
@@ -117,15 +117,19 @@ class CottontailDBClient:
         response = self._ddl.CreateEntity(CreateEntityMessage(txId=self._tid, definition=entity_def))
         return self._parse_query_response(response)
 
-    def drop_entity(self, schema, entity):
+    def drop_entity(self, schema, entity, not_exist_ok=True):
         """Drops the given entity from the given schema."""
+        if not_exist_ok and entity not in [s.split('.')[-1] for s in self.list_entities(schema)]:
+            return
         schema_name = SchemaName(name=schema)
         entity_name = EntityName(schema=schema_name, name=entity)
         response = self._ddl.DropEntity(DropEntityMessage(txId=self._tid, entity=entity_name))
         return self._parse_query_response(response)
 
-    def truncate_entity(self, schema, entity):
+    def truncate_entity(self, schema, entity, not_exist_ok=True):
         """Truncates the specified entity."""
+        if not_exist_ok and entity not in [s.split('.')[-1] for s in self.list_entities(schema)]:
+            return
         schema_name = SchemaName(name=schema)
         entity_name = EntityName(schema=schema_name, name=entity)
         response = self._ddl.TruncateEntity(TruncateEntityMessage(txId=self._tid, entity=entity_name))

--- a/cottontaildb_client/cottontaildb_client.py
+++ b/cottontaildb_client/cottontaildb_client.py
@@ -128,7 +128,7 @@ class CottontailDBClient:
         """Truncates the specified entity."""
         schema_name = SchemaName(name=schema)
         entity_name = EntityName(schema=schema_name, name=entity)
-        response = self._ddl.DropEntity(TruncateEntityMessage(txId=self._tid, entity=entity_name))
+        response = self._ddl.TruncateEntity(TruncateEntityMessage(txId=self._tid, entity=entity_name))
         return self._parse_query_response(response)
 
     def optimize_entity(self, schema, entity):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = cottontaildb-client
-version = 0.0.2
+version = 0.0.3
 author = Florian Spiess
 author_email = florian.spiess@unibas.ch
 description = A Cottontail DB gRPC client.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = cottontaildb-client
-version = 0.0.3
+version = 0.0.4
 author = Florian Spiess
 author_email = florian.spiess@unibas.ch
 description = A Cottontail DB gRPC client.

--- a/tests/test_cottontaildb_client.py
+++ b/tests/test_cottontaildb_client.py
@@ -49,6 +49,14 @@ class TestCottontailDBClient(TestCase):
         self.client.drop_entity(TEST_SCHEMA, TEST_ENTITY)
         self.assert_not_in(TEST_ENTITY, self.client.list_entities(TEST_SCHEMA), 'entity was not dropped')
 
+    def test_create_truncate_entity(self):
+        self._create_schema()
+        self._create_entity()
+        self.assert_in(TEST_ENTITY, self.client.list_entities(TEST_SCHEMA), 'entity was not created')
+        self.client.truncate_entity(TEST_SCHEMA, TEST_ENTITY)
+        self.assert_in(TEST_ENTITY, self.client.list_entities(TEST_SCHEMA), 'entity was dropped')
+
+
     def test_insert(self):
         self._create_schema()
         self._create_entity()

--- a/tests/test_cottontaildb_client.py
+++ b/tests/test_cottontaildb_client.py
@@ -49,13 +49,20 @@ class TestCottontailDBClient(TestCase):
         self.client.drop_entity(TEST_SCHEMA, TEST_ENTITY)
         self.assert_not_in(TEST_ENTITY, self.client.list_entities(TEST_SCHEMA), 'entity was not dropped')
 
+    def test_drop_not_exists_entity(self):
+        self._create_schema()
+        self.client.drop_entity(TEST_SCHEMA, TEST_ENTITY)
+
+    def test_truncate_not_exists_entity(self):
+        self._create_schema()
+        self.client.truncate_entity(TEST_SCHEMA, TEST_ENTITY)
+
     def test_create_truncate_entity(self):
         self._create_schema()
         self._create_entity()
         self.assert_in(TEST_ENTITY, self.client.list_entities(TEST_SCHEMA), 'entity was not created')
         self.client.truncate_entity(TEST_SCHEMA, TEST_ENTITY)
         self.assert_in(TEST_ENTITY, self.client.list_entities(TEST_SCHEMA), 'entity was dropped')
-
 
     def test_insert(self):
         self._create_schema()


### PR DESCRIPTION
- Adding not_exists_ok flags to truncate() and drop() method which means you can use them regardless of whether an entity exists or not
- Bumping Version to 0.0.4 (so this should be merged after #3)